### PR TITLE
refactor/kotest: AnnotationSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kotlin Shop
 ![Kotlin](https://img.shields.io/badge/Kotlin-2.0-603DC0.svg?style=flat&logo=kotlin&logoColor=white&labelColor=603DC0)
 ![JDK](https://img.shields.io/badge/JDK-21-3F90BD.svg?style=flat&logo=openjdk&logoColor=white&labelColor=3F90BD)
-![Gradle](https://img.shields.io/badge/gradle-8.10-02303A?style=flat&logo=gradle&logoColor=white&labelColor=02303A)
+![Gradle](https://img.shields.io/badge/gradle-8.x-02303A?style=flat&logo=gradle&logoColor=white&labelColor=02303A)
 ![GitHub Actions](https://github.com/iobruno/kotlin-shop/actions/workflows/kotlin-shop-ci.yml/badge.svg?branch-master&event=push)
 [![codecov](https://codecov.io/gh/iobruno/kotlin-shop/branch/master/graph/badge.svg?token=MYqE0qrhbs)](https://codecov.io/gh/iobruno/kotlin-shop)
 [![Maintainability](https://api.codeclimate.com/v1/badges/3203ff55a8ce4d832e8d/maintainability)](https://codeclimate.com/github/iobruno/kotlin-shop/maintainability)
@@ -14,8 +14,8 @@ and Subscription Orders
 
 ## Tech Stack
 - [Kotlin 2.x](https://github.com/JetBrains/kotlin/releases/tag/v2.0.20) (target: JVM 21)
-- [Kotest](https://kotest.io/) (assertion framework)
 - [JUnit 5](https://junit.org/junit5/) (test runner)
+- [Kotest Assertions](https://kotest.io/docs/assertions/assertions.html) (assertion framework)
 - [GitHub CI](https://docs.github.com/en/actions)
 
 ## Usage

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.gradle.internal.jvm.Jvm
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
@@ -16,12 +15,10 @@ repositories {
 }
 
 dependencies {
-    val junitVersion = "5.11.0"
-    val kotestVersion = "5.9.1"
+    val kotestVersion: String by project
     implementation(kotlin("stdlib"))
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
 }
 
 tasks.withType<KotlinJvmCompile>().configureEach {
@@ -31,8 +28,9 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     }
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    systemProperty("kotest.framework.classpath.scanning.autoscan.disable", "true")
 }
 
 tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,6 @@ tasks.withType<KotlinJvmCompile>().configureEach {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
-    systemProperty("kotest.framework.classpath.scanning.autoscan.disable", "true")
 }
 
 tasks.test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+kotestVersion=5.9.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/kotlin/io/petproject/model/AccountTest.kt
+++ b/src/test/kotlin/io/petproject/model/AccountTest.kt
@@ -1,10 +1,10 @@
 package io.petproject.model
 
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.Test
 
-internal class AccountTest {
+internal class AccountTest : AnnotationSpec() {
 
     @Test
     fun `when name is blank, throw IllegalArgEx`() {

--- a/src/test/kotlin/io/petproject/model/AddressTest.kt
+++ b/src/test/kotlin/io/petproject/model/AddressTest.kt
@@ -1,10 +1,11 @@
 package io.petproject.model
 
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.Test
 
-internal class AddressTest {
+
+internal class AddressTest : AnnotationSpec() {
 
     @Test
     fun `should build a valid address`() {

--- a/src/test/kotlin/io/petproject/model/DigitalOrderTest.kt
+++ b/src/test/kotlin/io/petproject/model/DigitalOrderTest.kt
@@ -1,13 +1,12 @@
 package io.petproject.model
 
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.petproject.model.ProductType.DIGITAL
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import java.time.YearMonth
 
-internal class DigitalOrderTest {
+internal class DigitalOrderTest : AnnotationSpec() {
 
     private val billingAddress: Address by lazy {
         Address.builder

--- a/src/test/kotlin/io/petproject/model/ItemTest.kt
+++ b/src/test/kotlin/io/petproject/model/ItemTest.kt
@@ -1,11 +1,11 @@
 package io.petproject.model
 
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.petproject.model.ProductType.PHYSICAL
-import org.junit.jupiter.api.Test
 
-internal class ItemTest {
+internal class ItemTest : AnnotationSpec() {
 
     @Test
     fun `when quantity is lower than or equalTo 0, throw IllegalArgEx`() {

--- a/src/test/kotlin/io/petproject/model/PhysicalOrderTest.kt
+++ b/src/test/kotlin/io/petproject/model/PhysicalOrderTest.kt
@@ -1,17 +1,16 @@
 package io.petproject.model
 
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.petproject.model.OrderStatus.DELIVERED
 import io.petproject.model.ProductType.DIGITAL
 import io.petproject.model.ProductType.PHYSICAL
 import io.petproject.model.ProductType.PHYSICAL_TAX_FREE
 import io.petproject.model.ShippingLabel.TAX_FREE
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import java.time.YearMonth
 
-internal class PhysicalOrderTest {
+internal class PhysicalOrderTest : AnnotationSpec() {
 
     private val billingAddress: Address by lazy {
         Address.builder

--- a/src/test/kotlin/io/petproject/model/ProductTest.kt
+++ b/src/test/kotlin/io/petproject/model/ProductTest.kt
@@ -1,10 +1,10 @@
 package io.petproject.model
 
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.Test
 
-internal class ProductTest {
+internal class ProductTest : AnnotationSpec() {
 
     @Test
     fun `when name is blank, throw IllegalArgEx`() {

--- a/src/test/kotlin/io/petproject/model/ShoppingCartTest.kt
+++ b/src/test/kotlin/io/petproject/model/ShoppingCartTest.kt
@@ -1,11 +1,11 @@
 package io.petproject.model
 
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 
-internal class ShoppingCartTest {
+
+internal class ShoppingCartTest : AnnotationSpec() {
     private val shoppingCart = ShoppingCart()
 
     @BeforeEach
@@ -30,6 +30,13 @@ internal class ShoppingCartTest {
             .add(spotify, 1)
             .add(amazon, 1)
     }
+
+    @AfterEach
+    fun clear() {
+        shoppingCart.items.clear()
+    }
+
+
 
     @Test
     fun `when adding a Product with quantity lowerThan or equalTo 0, throw IllegalArgEx`() {

--- a/src/test/kotlin/io/petproject/model/ShoppingCartTest.kt
+++ b/src/test/kotlin/io/petproject/model/ShoppingCartTest.kt
@@ -4,7 +4,6 @@ import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 
-
 internal class ShoppingCartTest : AnnotationSpec() {
     private val shoppingCart = ShoppingCart()
 
@@ -36,8 +35,6 @@ internal class ShoppingCartTest : AnnotationSpec() {
         shoppingCart.items.clear()
     }
 
-
-
     @Test
     fun `when adding a Product with quantity lowerThan or equalTo 0, throw IllegalArgEx`() {
         shouldThrowExactly<IllegalArgumentException> {
@@ -49,7 +46,7 @@ internal class ShoppingCartTest : AnnotationSpec() {
     fun `when adding a Product that is already in the Cart, add up to the quantity`() {
         val videoGameDigitalCopy = Product("Nier:Automata", ProductType.DIGITAL, 129.90)
         shoppingCart.add(videoGameDigitalCopy, 10)
-        shoppingCart.items.get(videoGameDigitalCopy).let { it?.quantity shouldBe 14  }
+        shoppingCart.items.get(videoGameDigitalCopy).let { it?.quantity shouldBe 14 }
     }
 
     @Test

--- a/src/test/kotlin/io/petproject/model/SubscriptionOrderTest.kt
+++ b/src/test/kotlin/io/petproject/model/SubscriptionOrderTest.kt
@@ -1,16 +1,15 @@
 package io.petproject.model
 
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.petproject.model.OrderStatus.ACTIVATED
 import io.petproject.model.OrderStatus.PENDING_ACTIVATION
 import io.petproject.model.ProductType.PHYSICAL
 import io.petproject.model.ProductType.SUBSCRIPTION
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import java.time.YearMonth
 
-internal class SubscriptionOrderTest {
+internal class SubscriptionOrderTest : AnnotationSpec() {
 
     private val billingAddress by lazy {
         Address.builder


### PR DESCRIPTION
## Summary

* Updates all tests to use Kotest `AnnotationSpec`
* Updates build.gradle.kts
  * Drops `junit-platform-launcher` in favor of `kotest-runner-junit5`
  * Extracts dependency versioning to gradle.properties
* Bumps gradle-wrapper to 8.11
* Updates README