### PR TITLE
chore/bumps-kotlin-fix-badges: Bumps Kotlin to 2.3.0 / Fixes GH Shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.1-262A38?style=flat-square&logo=kotlin&logoColor=603DC0&labelColor=262A38)](https://github.com/Kotlin/kotlin-spark-api)
 [![JDK](https://img.shields.io/badge/JDK-21_|_17-35667C?style=flat&logo=openjdk&logoColor=FFFFFF&labelColor=1D213B)](https://sdkman.io/)
+[![Gradle](https://img.shields.io/badge/gradle-9.3-31ADC3?style=flat&logo=gradle&logoColor=white&labelColor=011E24)](https://gradle.org/releases/)
 [![KoTest](https://img.shields.io/badge/Kotest-5.9-262A38.svg?style=flat&logo=kotlin&logoColor=16F802&labelColor=262A38)](https://kotest.io/docs/framework/testing-styles.html)
 [![JUnit 5](https://img.shields.io/badge/JUnit_5-262A38.svg?style=flat&logo=junit5&logoColor=white&labelColor=262A38)](https://junit.org/junit5/)
-[![Gradle](https://img.shields.io/badge/gradle-8.12-02303A?style=flat&logo=gradle&logoColor=white&labelColor=02303A)](https://gradle.org/releases/)
 
 ![GitHub Actions](https://github.com/iobruno/kotlin-shop/actions/workflows/kotlin-shop-ci.yml/badge.svg?branch-master&event=push)
 [![codecov](https://codecov.io/gh/iobruno/kotlin-shop/branch/master/graph/badge.svg?token=MYqE0qrhbs)](https://codecov.io/gh/iobruno/kotlin-shop)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Kotlin Shop
 
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.1-603DC0.svg?style=flat&logo=kotlin&logoColor=white&labelColor=603DC0)](https://github.com/JetBrains/kotlin/releases/tag/v2.1.10)
-[![JDK](https://img.shields.io/badge/JDK-21-1076C6?style=flat&logo=openjdk&logoColor=FFFFFF&labelColor=1076C6)](https://sdkman.io/)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.1-262A38?style=flat-square&logo=kotlin&logoColor=603DC0&labelColor=262A38)](https://github.com/Kotlin/kotlin-spark-api)
+[![JDK](https://img.shields.io/badge/JDK-21_|_17-35667C?style=flat&logo=openjdk&logoColor=FFFFFF&labelColor=1D213B)](https://sdkman.io/)
 [![KoTest](https://img.shields.io/badge/Kotest-5.9-262A38.svg?style=flat&logo=kotlin&logoColor=16F802&labelColor=262A38)](https://kotest.io/docs/framework/testing-styles.html)
 [![JUnit 5](https://img.shields.io/badge/JUnit_5-262A38.svg?style=flat&logo=junit5&logoColor=white&labelColor=262A38)](https://junit.org/junit5/)
 [![Gradle](https://img.shields.io/badge/gradle-8.12-02303A?style=flat&logo=gradle&logoColor=white&labelColor=02303A)](https://gradle.org/releases/)
 
 ![GitHub Actions](https://github.com/iobruno/kotlin-shop/actions/workflows/kotlin-shop-ci.yml/badge.svg?branch-master&event=push)
 [![codecov](https://codecov.io/gh/iobruno/kotlin-shop/branch/master/graph/badge.svg?token=MYqE0qrhbs)](https://codecov.io/gh/iobruno/kotlin-shop)
-[![Maintainability](https://api.codeclimate.com/v1/badges/3203ff55a8ce4d832e8d/maintainability)](https://codeclimate.com/github/iobruno/kotlin-shop/maintainability)
+[![Maintainability](https://qlty.sh/gh/iobruno/projects/kotlin-shop/maintainability.svg)](https://qlty.sh/gh/iobruno/projects/kotlin-shop)
 
 This is just a pet project of mine to play with Kotlin stdlib
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-kotlinVersion=2.1.10
+kotlinVersion=2.3.0
 kotestVersion=5.9.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

* Bumps Gradle to 9.3.0
* Bumps Kotlin to 2.3.0 to fix deprecation warnings for Gradle 10 compatibility
* Updates Kotlin, JDK and Gradle shields
* Fixes broken maintainability badge