### PR TITLE
fix/github-runner: Updates GitHub runner to ubuntu-slim

### DIFF
--- a/.github/workflows/kotlin-shop-ci.yml
+++ b/.github/workflows/kotlin-shop-ci.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Summary

* Bumps runner to ubuntu-slim as ubuntu-20.04 is deprecated
  and keeps the GH Action stale in waiting